### PR TITLE
Updates for node 6.9.4 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,5 @@ RUN apt-get update && \
     apt-add-repository -y ppa:reddit/ppa && apt-get update
 
 RUN apt-get install -y nodejs git-core
-# The npm 2.x that comes with our PPA's nodejs fails to resolve dependencies
-# correctly for this project. npm 3.x+ can handle it. Force an upgrade until
-# we can re-evaluate packaging (or upgrade to and package nodejs 5.x + npm 3.x).
-RUN npm install npm -g
 
 CMD [""]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ build:
 	docker build -t reddit/reddit-nodejs:local .
 
 run:
-	docker run --rm -it reddit/reddit-nocejs:local bash
+	docker run --rm -it reddit/reddit-nodejs:local bash
 
 default: build


### PR DESCRIPTION
Our node 6.9.4 package in the reddit PPA comes with npm 3.10.10, so we shouldn't need the explicit npm upgrade anymore. There's also a fixup commit for `noce` -> `node` in the Makefile. 

This should also force a master build in drone which should publish a node 6.9.4 latest image to Quay.

:eyeglasses: @gtaylor 
